### PR TITLE
DO NOT MERGE Update Dockerfile to run with External Toolchain

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,18 @@
-FROM websphere-liberty:kernel
+FROM ibmjava:8-sdk AS builder
 LABEL maintainer="IBM Java Engineering at IBM Cloud"
-COPY --chown=1001:0 /target/liberty/wlp/usr/servers/defaultServer /config/
+
+WORKDIR /app
+COPY . /app
+
+RUN apt-get update && apt-get install -y maven
+RUN mvn -N io.takari:maven:wrapper -Dmaven=3.5.0
+RUN ./mvnw install
+
+FROM websphere-liberty:webProfile7
+LABEL maintainer="IBM Java Engineering at IBM Cloud"
+ENV PATH /project/target/liberty/wlp/bin/:$PATH
+
+COPY --from=builder /app/target/liberty/wlp/usr/servers/defaultServer /config/
 # Grant write access to apps folder, this is to support old and new docker versions.
 # Liberty document reference : https://hub.docker.com/_/websphere-liberty/
 USER root
@@ -10,13 +22,13 @@ USER 1001
 RUN installUtility install --acceptLicense defaultServer
 
 # Upgrade to production license if URL to JAR provided
-ARG LICENSE_JAR_URL
-RUN \ 
-  if [ $LICENSE_JAR_URL ]; then \
-    wget $LICENSE_JAR_URL -O /tmp/license.jar \
-    && java -jar /tmp/license.jar -acceptLicense /opt/ibm \
-    && rm /tmp/license.jar; \
-  fi
+#ARG LICENSE_JAR_URL
+#RUN \ 
+#  if [ $LICENSE_JAR_URL ]; then \
+#    wget $LICENSE_JAR_URL -O /tmp/license.jar \
+#    && java -jar /tmp/license.jar -acceptLicense /opt/ibm \
+#    && rm /tmp/license.jar; \
+#  fi
 
 # This script will add the requested XML snippets, grow image to be fit-for-purpose and apply interim fixes
-RUN configure.sh
+#RUN configure.sh


### PR DESCRIPTION
This PR is needed to run a complete Java Project build inside the dockerfile. Our Dockerfiles will no longer be able to count on the Toolchain or external environment to always compile the .jar file. We are updating this dockerfile to run a 2-stage Docker build, where the first stage downloads dependencies, and compiles the .jar, and then the second stage copies it over from the first container, and the first container is destroyed. This change is to work with the External OpenToolchain Toolchain templates that DevX is transitioning to.